### PR TITLE
Fix planning board display in Threadline

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="FastReact - A modern React development framework" />
+    <meta name="description" content="Threadline - Production planning and scheduling" />
     <meta name="theme-color" content="#3b82f6" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <title>FastReact App</title>
+    <title>Threadline</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/pages/PlanningBoard.tsx
+++ b/frontend/pages/PlanningBoard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd'
 import { format, addDays, differenceInDays, parseISO } from 'date-fns'
 import { AlertTriangle, CheckCircle } from 'lucide-react'
+import { API_BASE_URL } from '@/config'
 
 interface Order {
   order_id: number
@@ -54,7 +55,7 @@ const PlanningBoard: React.FC = () => {
   const fetchOrders = async () => {
     try {
       setLoading(true)
-      const response = await fetch('http://localhost:3001/api/orders')
+      const response = await fetch(`${API_BASE_URL}/orders`)
       if (!response.ok) {
         throw new Error('Failed to fetch orders')
       }
@@ -81,7 +82,7 @@ const PlanningBoard: React.FC = () => {
   // Update order dates
   const updateOrderDates = async (orderId: number, startDate: string, endDate: string) => {
     try {
-      const response = await fetch('http://localhost:3001/api/updateOrder', {
+      const response = await fetch(`${API_BASE_URL}/updateOrder`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -33,7 +33,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                   <div className="absolute -top-1 -right-1 w-3 h-3 bg-gradient-to-r from-success-400 to-success-600 rounded-full animate-pulse"></div>
                 </div>
                 <div>
-                  <span className="text-xl font-bold text-gradient-sunset font-display">Planning Tool</span>
+                  <span className="text-xl font-bold text-gradient-sunset font-display">Threadline</span>
                   <p className="text-xs text-gray-500 -mt-1">Production Management</p>
                 </div>
               </Link>
@@ -61,7 +61,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
             {/* Right side actions */}
             <div className="hidden md:flex items-center space-x-3">
-              <button className="p-2 rounded-xl text-gray-600 hover:text-primary-600 hover:bg:white/50 transition-all duration-300">
+              <button className="p-2 rounded-xl text-gray-600 hover:text-primary-600 hover:bg-white/50 transition-all duration-300">
                 <BarChart3 className="h-5 w-5" />
               </button>
               <button className="p-2 rounded-xl text-gray-600 hover:text-primary-600 hover:bg-white/50 transition-all duration-300">
@@ -128,7 +128,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           <div className="text-center">
             <div className="flex items-center justify-center space-x-2 mb-2">
               <Calendar className="h-5 w-5 text-primary-600" />
-              <span className="text-gradient font-medium">Planning Tool</span>
+              <span className="text-gradient font-medium">Threadline</span>
             </div>
             <p className="text-gray-500 text-sm">
               Drag-and-drop production planning with intelligent BOM checking

--- a/frontend/src/pages/PlanningBoard.tsx
+++ b/frontend/src/pages/PlanningBoard.tsx
@@ -263,7 +263,7 @@ const PlanningBoard: React.FC = () => {
       {/* Order Details Modal */}
       {selectedOrder && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg:white rounded-lg max-w-md w-full max-h-[80vh] overflow-y-auto">
+          <div className="bg-white rounded-lg max-w-md w-full max-h-[80vh] overflow-y-auto">
             <div className="p-6">
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-lg font-semibold text-gray-900">

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,6 +2,9 @@
 export default {
   content: [
     "./index.html",
+    "./App.tsx",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./pages/**/*.{js,ts,jsx,tsx}",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -26,6 +26,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "App.tsx", "components", "pages"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Fixes Planning Board display by correcting Tailwind CSS configuration and styling typos, updates branding to 'Threadline', and standardizes API base URL usage.

The Planning Board was not rendering correctly due to Tailwind CSS not processing styles from `pages` and `components` directories, and minor styling typos in modal and hover effects. Branding was updated to "Threadline" as requested. API base URL usage was standardized for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-d62bbc1b-ba2c-48f8-8388-c1b4f915c9d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d62bbc1b-ba2c-48f8-8388-c1b4f915c9d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

